### PR TITLE
Allow connection as a parameter to VerticaBatch

### DIFF
--- a/pyvertica/batch.py
+++ b/pyvertica/batch.py
@@ -205,15 +205,12 @@ class VerticaBatch(object):
             reconnect=True,
             analyze_constraints=True,
             column_list=[],
-            copy_options={}):
-        # make sure we are not logging any passwords :)
-        odbc_kwargs_copy = copy.deepcopy(odbc_kwargs)
-        if 'password' in odbc_kwargs_copy:
-            odbc_kwargs_copy['password'] = '*****'
-        logger.debug(
-            'Initializing VerticaBatch with odbc_kwargs={0}, table_name={1}, '
-            'column_list={2}'.format(
-                odbc_kwargs_copy, table_name, column_list))
+            copy_options={},
+            connection=None):
+
+        if connection and odbc_kwargs:
+            raise ValueError("May only specify one of [connection, odbc_kwargs]")
+
 
         self._odbc_kwargs = odbc_kwargs
         self._table_name = table_name
@@ -226,9 +223,20 @@ class VerticaBatch(object):
 
         self._in_batch = False
 
-        # setup db connection
-        self._connection = get_connection(
-            reconnect=reconnect, **self._odbc_kwargs)
+         # make sure we are not logging any passwords :)
+        if not connection:
+            odbc_kwargs_copy = copy.deepcopy(odbc_kwargs)
+            if 'password' in odbc_kwargs_copy:
+                odbc_kwargs_copy['password'] = '*****'
+            logger.debug(
+                'Initializing VerticaBatch with odbc_kwargs={0}, table_name={1}, '
+                'column_list={2}'.format(
+                    odbc_kwargs_copy, table_name, column_list))
+            self._connection = get_connection(
+                reconnect=reconnect, **self._odbc_kwargs)
+        else:
+            self._connection = connection
+
         self._cursor = self._connection.cursor()
 
         # truncate table, if needed

--- a/pyvertica/batch.py
+++ b/pyvertica/batch.py
@@ -209,8 +209,8 @@ class VerticaBatch(object):
             connection=None):
 
         if connection and odbc_kwargs:
-            raise ValueError("May only specify one of [connection, odbc_kwargs]")
-
+            raise ValueError("May only specify one of "
+                             "[connection, odbc_kwargs]")
 
         self._odbc_kwargs = odbc_kwargs
         self._table_name = table_name
@@ -229,7 +229,8 @@ class VerticaBatch(object):
             if 'password' in odbc_kwargs_copy:
                 odbc_kwargs_copy['password'] = '*****'
             logger.debug(
-                'Initializing VerticaBatch with odbc_kwargs={0}, table_name={1}, '
+                'Initializing VerticaBatch with odbc_kwargs={0}, '
+                'table_name={1}, '
                 'column_list={2}'.format(
                     odbc_kwargs_copy, table_name, column_list))
             self._connection = get_connection(

--- a/pyvertica/tests/unit/test_batch.py
+++ b/pyvertica/tests/unit/test_batch.py
@@ -174,16 +174,17 @@ class VerticaBatchTestCase(unittest.TestCase):
         """"
         Test passing connection to VerticaBatch instead of odbc_kwargs.
         """
-        connection = "mock_connection"
+        connection = Mock()
         batch = VerticaBatch(table_name='table',
                              column_list=[],
                              connection=connection)
         self.assertEqual(connect, batch._connection)
+        connection.cursor.assert_any_call()
 
     def test__init__connection_or_odbc_kwargs(self):
         args = {
             'odbc_kwargs': {'dsn': 'TestDSN'},
-            'connection': 'connection'
+            'connection': Mock()
         }
         try:
             VerticaBatch(table_name='table',

--- a/pyvertica/tests/unit/test_batch.py
+++ b/pyvertica/tests/unit/test_batch.py
@@ -183,7 +183,7 @@ class VerticaBatchTestCase(unittest.TestCase):
             'odbc_kwargs': {'dsn': 'TestDSN'},
             'connection': 'connection'
         }
-        self.assertRaises(ValueError, VerticaBatch.__init__,  **args)
+        self.assertRaises(ValueError, VerticaBatch.__init__, **args)
 
     @patch('pyvertica.batch.get_connection')
     def test_truncate_table(self, get_connection):

--- a/pyvertica/tests/unit/test_batch.py
+++ b/pyvertica/tests/unit/test_batch.py
@@ -170,6 +170,21 @@ class VerticaBatchTestCase(unittest.TestCase):
         self.get_batch(truncate_table=True)
         truncate_table.assert_called_once_with()
 
+    def test__init__connection(self):
+        """"
+        Test passing connection to VerticaBatch instead of odbc_kwargs.
+        """
+        connection = "mock_connection"
+        batch = VerticaBatch(connection=connection)
+        self.assertEqual(connect, batch._connection)
+
+    def test__init__connection_or_odbc_kwargs(self):
+        args = {
+            'odbc_kwargs': {'dsn': 'TestDSN'},
+            'connection': 'connection'
+        }
+        self.assertRaises(ValueError, VerticaBatch.__init__,  **args)
+
     @patch('pyvertica.batch.get_connection')
     def test_truncate_table(self, get_connection):
         """

--- a/pyvertica/tests/unit/test_batch.py
+++ b/pyvertica/tests/unit/test_batch.py
@@ -178,7 +178,7 @@ class VerticaBatchTestCase(unittest.TestCase):
         batch = VerticaBatch(table_name='table',
                              column_list=[],
                              connection=connection)
-        self.assertEqual(connect, batch._connection)
+        self.assertEqual(connection, batch._connection)
         connection.cursor.assert_any_call()
 
     def test__init__connection_or_odbc_kwargs(self):

--- a/pyvertica/tests/unit/test_batch.py
+++ b/pyvertica/tests/unit/test_batch.py
@@ -175,7 +175,9 @@ class VerticaBatchTestCase(unittest.TestCase):
         Test passing connection to VerticaBatch instead of odbc_kwargs.
         """
         connection = "mock_connection"
-        batch = VerticaBatch(connection=connection)
+        batch = VerticaBatch(table_name='table',
+                             column_list=[],
+                             connection=connection)
         self.assertEqual(connect, batch._connection)
 
     def test__init__connection_or_odbc_kwargs(self):
@@ -183,7 +185,14 @@ class VerticaBatchTestCase(unittest.TestCase):
             'odbc_kwargs': {'dsn': 'TestDSN'},
             'connection': 'connection'
         }
-        self.assertRaises(ValueError, VerticaBatch.__init__, **args)
+        try:
+            VerticaBatch(table_name='table',
+                         column_list=[],
+                         odbc_kwargs=args,
+                         connection="connection")
+            self.fail("Should throw ValueError")
+        except ValueError:
+            pass
 
     @patch('pyvertica.batch.get_connection')
     def test_truncate_table(self, get_connection):


### PR DESCRIPTION
I would like to be able to pass a pyodbc connection into a VerticaBatch so a new connection does not need to be established for each batch. Thoughts?
