### PR TITLE
remove threads from batch insert code

### DIFF
--- a/pyvertica/batch.py
+++ b/pyvertica/batch.py
@@ -254,8 +254,8 @@ class VerticaBatch(object):
                 temp_file_path = self._csv_file_obj.name
                 os.remove(temp_file_path)
         except:
-            pass 
-        
+            pass
+
         self._in_batch = False
         ended_clean = True
         logger.debug('Batch ended')

--- a/pyvertica/batch.py
+++ b/pyvertica/batch.py
@@ -32,6 +32,7 @@ def require_started_batch(func):
         return func(self, *args, **kwargs)
     return inner_func
 
+
 class VerticaBatch(object):
     """
     Object for writing multiple records to Vertica in a batch.
@@ -224,10 +225,10 @@ class VerticaBatch(object):
             self._initialize_batch()
 
         self._csv_file_obj = tempfile.NamedTemporaryFile('w')
-        temp_file_path= self._csv_file_obj.name
+        temp_file_path = self._csv_file_obj.name
         self._csv_file_obj.close()
         self._csv_file_obj = codecs.open(temp_file_path, 'w', 'utf-8')
-        
+
         logger.debug('Batch started')
 
     @require_started_batch
@@ -583,4 +584,4 @@ class VerticaBatch(object):
             Instance of :py:class:`!pyodbc.Cursor`.
 
         """
-        return self._connection.cursor() 
+        return self._connection.cursor()


### PR DESCRIPTION
Tested multiple times and worked fine. This has been done to resolve #27 . Somehow python threads or my pyodbc/vertica server can't work together. This is safer and simpler. 
